### PR TITLE
Fix freeze in macOs.

### DIFF
--- a/main.py
+++ b/main.py
@@ -44,12 +44,14 @@ class DoubleTriggerFilterView:
         self.rescan()
         self.load_config()
 
-        def stats_updated_cb():
+        def update_stats():
             self.notes_on_events_passed.set(self.midi_filter.notes_on_events_passed)
             self.notes_on_events_skipped.set(self.midi_filter.notes_on_events_skipped)
-        self.midi_filter.stats_updated_cb = stats_updated_cb
-        stats_updated_cb()
 
+        REFRESH_GUI_EVENT = '<<RefreshGUI>>'
+        self.root.bind(REFRESH_GUI_EVENT, lambda event: update_stats())
+        self.midi_filter.stats_updated_cb = lambda: self.root.event_generate(REFRESH_GUI_EVENT, when="tail")
+        self.midi_filter.stats_updated_cb()
 
         def set_min_velocity(*args):
             try:

--- a/main.py
+++ b/main.py
@@ -76,6 +76,8 @@ class DoubleTriggerFilterView:
 
         if self.autostart.get():
             self.start()
+        else:
+            self.update_status()
 
 
     def load_config(self):

--- a/main.py
+++ b/main.py
@@ -115,7 +115,10 @@ class DoubleTriggerFilterView:
 
 
     def start(self):
-        self.midi_filter.start(self.iportname.get(), self.oportname.get())
+        try:
+            self.midi_filter.start(self.iportname.get(), self.oportname.get())
+        except OverflowError as e:
+            debug_log('Exception in midi_filter:', e)
         self.update_status()
 
 

--- a/main.py
+++ b/main.py
@@ -221,7 +221,7 @@ class DoubleTriggerFilterView:
 # Config.
 config_dir = appdirs.user_config_dir('midi-note-double-trigger-filter', '')
 config_path = os.path.join(config_dir, 'midi-note-double-trigger-filter.cfg')
-xprint('Config at:', config_path)
+debug_log('Config at:', config_path)
 config = configparser.ConfigParser()
 config.read(config_path)
 if 'general' not in config: config.add_section('general')
@@ -246,4 +246,4 @@ if not os.path.exists(config_dir):
     os.makedirs(config_dir)
 config.write(open(config_path, 'w'))
 
-xprint('EXIT')
+debug_log('EXIT')

--- a/main.py
+++ b/main.py
@@ -44,7 +44,6 @@ class DoubleTriggerFilterView:
         self.rescan()
         self.load_config()
 
-
         def stats_updated_cb():
             self.notes_on_events_passed.set(self.midi_filter.notes_on_events_passed)
             self.notes_on_events_skipped.set(self.midi_filter.notes_on_events_skipped)
@@ -60,7 +59,6 @@ class DoubleTriggerFilterView:
             self.midi_filter.min_velocity = v
         self.min_velocity.trace('w', set_min_velocity)
 
-
         def set_min_delay(*args):
             try:
                 v = float(self.min_delay.get())
@@ -68,7 +66,6 @@ class DoubleTriggerFilterView:
                 v = 0
             self.midi_filter.min_delay = v
         self.min_delay.trace('w', set_min_delay)
-
 
         def filter1_enabled(*args):
             self.midi_filter.enabled = self.filter1_enabled.get()

--- a/main.py
+++ b/main.py
@@ -24,17 +24,17 @@ class DoubleTriggerFilterView:
         self.config = config
 
         # vars
-        self.iportname = tk.StringVar(window)
-        self.oportname = tk.StringVar(window)
-        self.status = tk.StringVar(window)
-        self.autostart = tk.IntVar(window)
+        self.iportname = tk.StringVar(self.root)
+        self.oportname = tk.StringVar(self.root)
+        self.status = tk.StringVar(self.root)
+        self.autostart = tk.IntVar(self.root)
 
-        self.filter1_enabled = tk.IntVar(window)
-        self.min_delay = tk.StringVar(window)
-        self.min_velocity = tk.StringVar(window)
+        self.filter1_enabled = tk.IntVar(self.root)
+        self.min_delay = tk.StringVar(self.root)
+        self.min_velocity = tk.StringVar(self.root)
 
-        self.notes_on_events_passed = tk.IntVar(window)
-        self.notes_on_events_skipped = tk.IntVar(window)
+        self.notes_on_events_passed = tk.IntVar(self.root)
+        self.notes_on_events_skipped = tk.IntVar(self.root)
 
         self.setup_devices_frame()
         self.setup_filter_frame()
@@ -212,43 +212,46 @@ class DoubleTriggerFilterView:
 
 
     def setup_operations_frame(self):
-        operation_frame = tk.Frame(window)
+        operation_frame = tk.Frame(self.root)
         operation_frame.pack()
 
         start_btn = ttk.Button(operation_frame, textvariable = self.status, command = lambda:self.toggle_start_stop())
-        start_btn.pack(pady=5, ipady=2)
+        start_btn.pack(pady=5, ipady=5)
 
-        autostart_chkbtn = ttk.Checkbutton(window, text='Autostart', variable = self.autostart)
+        autostart_chkbtn = ttk.Checkbutton(operation_frame, text='Autostart', variable = self.autostart)
         autostart_chkbtn.pack(pady=10)
 
 
+def main():
+    # Config.
+    config_dir = appdirs.user_config_dir('midi-note-double-trigger-filter', '')
+    config_path = os.path.join(config_dir, 'midi-note-double-trigger-filter.cfg')
+    debug_log('Config at:', config_path)
+    config = configparser.ConfigParser()
+    config.read(config_path)
+    if 'general' not in config: config.add_section('general')
+    if 'filter1' not in config: config.add_section('filter1')
 
-# Config.
-config_dir = appdirs.user_config_dir('midi-note-double-trigger-filter', '')
-config_path = os.path.join(config_dir, 'midi-note-double-trigger-filter.cfg')
-debug_log('Config at:', config_path)
-config = configparser.ConfigParser()
-config.read(config_path)
-if 'general' not in config: config.add_section('general')
-if 'filter1' not in config: config.add_section('filter1')
+    # Model and view
+    window = tk.Tk()
+    window.title("MIDI Note Double Trigger Filter")
 
-# Model and view
-window = tk.Tk()
-window.title("MIDI Note Double Trigger Filter")
+    midi_filter = MIDIFilter()
+    view = DoubleTriggerFilterView(window, midi_filter, config)
 
-midi_filter = MIDIFilter()
-view = DoubleTriggerFilterView(window, midi_filter, config)
+    window.update()
+    window.minsize(window.winfo_width(), window.winfo_height())
+    window.mainloop()
 
-window.update()
-window.minsize(window.winfo_width(), window.winfo_height())
-window.mainloop()
+    midi_filter.stats_updated_cb = None
+    view.update_config()
 
-midi_filter.stats_updated_cb = None
-view.update_config()
+    # Save config to file
+    if not os.path.exists(config_dir):
+        os.makedirs(config_dir)
+    config.write(open(config_path, 'w'))
 
-# Save config to file
-if not os.path.exists(config_dir):
-    os.makedirs(config_dir)
-config.write(open(config_path, 'w'))
+    debug_log('EXIT')
 
-debug_log('EXIT')
+
+main()

--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2018 Gennadi Iosad.
 # All Rights Reserved.
 # You may use, distribute and modify this code under the

--- a/midi_filter.py
+++ b/midi_filter.py
@@ -13,7 +13,7 @@ import rtmidi
 import sys
 import time
 
-def xprint(*args, **kwargs):
+def debug_log(*args, **kwargs):
     t = time.time()
     timestamp = time.strftime('%H:%M:%S', time.localtime(t)) + '.{:03}'.format(int(t * 1000) % 1000)
     print(timestamp, *args, **kwargs)
@@ -98,20 +98,20 @@ class MIDIFilter:
             else:
                 self.notes_on_events_skipped += 1
                 self.stats_updated()
-                xprint('Skipping note_on of note {}, delta {:.3f}, velocity={}'.format(msg[1], delta, msg[2]))
+                debug_log('Skipping note_on of note {}, delta {:.3f}, velocity={}'.format(msg[1], delta, msg[2]))
 
         self._oport.open_port(self._port_index_by_name(self._oport, oportname))
         if not self._oport.is_port_open():
-            xprint('Output MIDI device is not found')
+            debug_log('Output MIDI device is not found')
             return
 
         self._iport.set_callback(handle_in)
         self._iport.open_port(self._port_index_by_name(self._iport, iportname))
         if not self._iport.is_port_open():
-            xprint('Input MIDI device is not found')
+            debug_log('Input MIDI device is not found')
             return
 
-        xprint('Ports open')
+        debug_log('Ports open')
         self._is_running = True
 
 
@@ -126,4 +126,4 @@ class MIDIFilter:
             self._oport.close_port()
             self._oport = None
 
-        xprint('MIDI ports closed')
+        debug_log('MIDI ports closed')


### PR DESCRIPTION
The direct access to tkinter variables on non-main thread e.g. rtmidi callback thread leads to hang ups.
Solve this by using event_generate() to generate virtual events that wake tkinter main loop and update the variables accordingly.